### PR TITLE
fix: reduce surreal features

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,12 +133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea50b14b7a4b9343f8c627a7a53c52076482bd4bdad0a24fd3ec533ed616cc2c"
 
 [[package]]
-name = "anyhow"
-version = "1.0.75"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4668cab20f66d8d020e1fbc0ebe47217433c1b6c8f2040faf858554e394ace6"
-
-[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,42 +210,9 @@ dependencies = [
 
 [[package]]
 name = "async-recursion"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7d78656ba01f1b93024b7c3a0467f1608e4be67d725749fdcd7d2c7678fd7a2"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "async-recursion"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5fd55a5ba1179988837d24ab4c7cc8ed6efdeff578ede0416b4225a5fca35bd0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
-]
-
-[[package]]
-name = "async-stream"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd56dd203fef61ac097dd65721a419ddccb106b2d2b70ba60a6b529f03961a51"
-dependencies = [
- "async-stream-impl",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-stream-impl"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16e62a023e7c117e27523144c5d2459f4397fcc3cab0085af8e2224f643a0193"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -481,29 +442,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.65.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cfdf7b466f9a4903edc73f95d6d2bcd5baf8ae620638762244d3f60143643cc5"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 2.0.39",
- "which",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -692,17 +630,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
 
 [[package]]
-name = "bzip2-sys"
-version = "0.1.11+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -769,15 +696,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
-]
-
-[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -806,17 +724,6 @@ checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
  "crypto-common",
  "inout",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c688fc74432808e3eb684cae8830a86be1d66a2bd58e1f248ed0960a590baf6f"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -1099,17 +1006,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive-new"
-version = "0.5.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3418329ca0ad70234b9735dc4ceed10af4df60eff9c8e7b06cb5e520d92c3535"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "derive_more"
 version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1283,17 +1179,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
 
 [[package]]
-name = "fail"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3be3c61c59fdc91f5dbc3ea31ee8623122ce80057058be560654c5d410d181a6"
-dependencies = [
- "lazy_static",
- "log",
- "rand 0.7.3",
-]
-
-[[package]]
 name = "fastbloom-rs"
 version = "0.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,56 +1272,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a62bc1cf6f830c2ec14a513a9fb124d0a213a629668a4186f329db21fe045652"
 dependencies = [
  "percent-encoding",
-]
-
-[[package]]
-name = "foundationdb"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8696fd1be198f101eb58aeecf0f504fc02b28c7afcc008b4e4a998a91b305108"
-dependencies = [
- "async-recursion 1.0.5",
- "async-trait",
- "foundationdb-gen",
- "foundationdb-macros",
- "foundationdb-sys",
- "futures",
- "memchr",
- "rand 0.8.5",
- "serde",
- "serde_bytes",
- "serde_json",
- "static_assertions",
-]
-
-[[package]]
-name = "foundationdb-gen"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62239700f01b041b6372aaeb847c52f960e1a69fd2b1025dc995ea3dd90e3308"
-dependencies = [
- "xml-rs",
-]
-
-[[package]]
-name = "foundationdb-macros"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83c8d52fe8b46ab822b4decdcc0d6d85aeedfc98f0d52ba2bd4aec4a97807516"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.39",
- "try_map",
-]
-
-[[package]]
-name = "foundationdb-sys"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98e49545f5393d276b7b888c77e3f9519fd33727435f8244344be72c3284256f"
-dependencies = [
- "bindgen",
 ]
 
 [[package]]
@@ -1690,12 +1525,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 
 [[package]]
-name = "glob"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
-
-[[package]]
 name = "h2"
 version = "0.3.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1902,18 +1731,6 @@ dependencies = [
  "rustls 0.21.8",
  "tokio",
  "tokio-rustls 0.24.1",
-]
-
-[[package]]
-name = "hyper-timeout"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
-dependencies = [
- "hyper",
- "pin-project-lite",
- "tokio",
- "tokio-io-timeout",
 ]
 
 [[package]]
@@ -2132,12 +1949,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lexicmp"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2151,16 +1962,6 @@ name = "libc"
 version = "0.2.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
-
-[[package]]
-name = "libloading"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
-dependencies = [
- "cfg-if",
- "winapi",
-]
 
 [[package]]
 name = "libm"
@@ -2180,37 +1981,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "librocksdb-sys"
-version = "0.11.0+8.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3386f101bcb4bd252d8e9d2fb41ec3b0862a15a62b478c355b2982efa469e3e"
-dependencies = [
- "bindgen",
- "bzip2-sys",
- "cc",
- "glob",
- "libc",
- "libz-sys",
- "lz4-sys",
- "zstd-sys",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
-dependencies = [
- "cc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "libz-sys"
-version = "1.1.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d97137b25e321a73eef1418d1d5d2eda4d77e12813f8e6dead84bc52c5870a7b"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2261,16 +2035,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31e24f1ad8321ca0e8a1e0ac13f23cb668e6f5466c2c57319f6a5cf1cc8e3b1c"
 dependencies = [
  "linked-hash-map",
-]
-
-[[package]]
-name = "lz4-sys"
-version = "1.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d27b317e207b10f69f5e75494119e391a96f48861ae870d1da6edac98ca900"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]
@@ -2726,12 +2490,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pem"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2892,16 +2650,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
-name = "prettyplease"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae005bd773ab59b4725093fd7df83fd7892f7d8eafb48dbd7de6e024e4215f9d"
-dependencies = [
- "proc-macro2",
- "syn 2.0.39",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2941,43 +2689,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
 dependencies = [
  "unicode-ident",
-]
-
-[[package]]
-name = "prometheus"
-version = "0.13.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "449811d15fbdf5ceb5c1144416066429cf82316e2ec8ce0c1f6f8a02e7bbcf8c"
-dependencies = [
- "cfg-if",
- "fnv",
- "lazy_static",
- "memchr",
- "parking_lot",
- "thiserror",
-]
-
-[[package]]
-name = "prost"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b82eaa1d779e9a4bc1c3217db8ffbeabaae1dca241bf70183242128d48681cd"
-dependencies = [
- "bytes",
- "prost-derive",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5d2d8d10f3c6ded6da8b05b5fb3b8a5082514344d56c9f871412d29b4e075b4"
-dependencies = [
- "anyhow",
- "itertools 0.10.5",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3447,16 +3158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cbf4a6aa5f6d6888f39e980649f3ad6b666acdce1d78e95b8a2cb076e687ae30"
 
 [[package]]
-name = "rocksdb"
-version = "0.21.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb6f170a4041d50a0ce04b0d2e14916d6ca863ea2e422689a5b694395d299ffe"
-dependencies = [
- "libc",
- "librocksdb-sys",
-]
-
-[[package]]
 name = "rsa"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3529,12 +3230,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc_lexer"
@@ -3898,12 +3593,6 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
-
-[[package]]
-name = "shlex"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7cee0529a6d40f580e7a5e6c495c8fbfe21b7b52795ed4bb5e62cdf92bc6380"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4289,12 +3978,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "static_assertions"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
-
-[[package]]
 name = "storekey"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4364,7 +4047,7 @@ dependencies = [
  "argon2",
  "async-channel",
  "async-executor",
- "async-recursion 1.0.5",
+ "async-recursion",
  "base64 0.21.5",
  "bcrypt",
  "bincode",
@@ -4375,7 +4058,6 @@ dependencies = [
  "dmp",
  "echodb",
  "flume 0.10.14",
- "foundationdb",
  "fst",
  "futures",
  "futures-concurrency",
@@ -4399,7 +4081,6 @@ dependencies = [
  "reqwest",
  "revision",
  "roaring",
- "rocksdb",
  "rust-stemmers",
  "rust_decimal",
  "rustls 0.20.9",
@@ -4413,7 +4094,6 @@ dependencies = [
  "storekey",
  "surrealdb-derive",
  "surrealdb-jsonwebtoken",
- "surrealdb-tikv-client",
  "thiserror",
  "tokio",
  "tokio-tungstenite",
@@ -4454,33 +4134,6 @@ dependencies = [
  "serde_json",
  "sha2",
  "simple_asn1",
-]
-
-[[package]]
-name = "surrealdb-tikv-client"
-version = "0.2.0-surreal.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b79f921871d6ed67c970e8499b4aca3724115c189f99ab30f51b46c77bd19819"
-dependencies = [
- "async-recursion 0.3.2",
- "async-trait",
- "derive-new",
- "either",
- "fail",
- "futures",
- "lazy_static",
- "log",
- "pin-project",
- "prometheus",
- "prost",
- "rand 0.8.5",
- "regex",
- "semver 1.0.20",
- "serde",
- "serde_derive",
- "thiserror",
- "tokio",
- "tonic",
 ]
 
 [[package]]
@@ -4672,16 +4325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-io-timeout"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
-dependencies = [
- "pin-project-lite",
- "tokio",
-]
-
-[[package]]
 name = "tokio-macros"
 version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4765,37 +4408,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tonic"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3082666a3a6433f7f511c7192923fa1fe07c69332d3c6a2e6bb040b569199d5a"
-dependencies = [
- "async-stream",
- "async-trait",
- "axum",
- "base64 0.21.5",
- "bytes",
- "futures-core",
- "futures-util",
- "h2",
- "http",
- "http-body",
- "hyper",
- "hyper-timeout",
- "percent-encoding",
- "pin-project",
- "prost",
- "rustls-pemfile",
- "tokio",
- "tokio-rustls 0.24.1",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4803,13 +4415,9 @@ checksum = "b8fa9be0de6cf49e536ce1851f987bd21a43b771b09473c3549a6c853db37c1c"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 1.9.3",
  "pin-project",
  "pin-project-lite",
- "rand 0.8.5",
- "slab",
  "tokio",
- "tokio-util",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -4920,12 +4528,6 @@ name = "try-lock"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3528ecfd12c466c6f163363caf2d02a71161dd5e1cc6ae7b34207ea2d42d81ed"
-
-[[package]]
-name = "try_map"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb1626d07cb5c1bb2cf17d94c0be4852e8a7c02b041acec9a8c5bdda99f9d580"
 
 [[package]]
 name = "tungstenite"
@@ -5272,18 +4874,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "14247bb57be4f377dfb94c72830b8ce8fc6beac03cf4bf7b9732eadd414123fc"
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix",
-]
-
-[[package]]
 name = "whoami"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5431,12 +5021,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "xml-rs"
-version = "0.8.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
-
-[[package]]
 name = "xorfilter-rs"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5473,13 +5057,3 @@ name = "zeroize"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a0956f1ba7c7909bfb66c2e9e4124ab6f6482560f6628b5aaeba39207c9aad9"
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,8 +89,7 @@ features = [
     "sqlite-rustls",
     "mysql-rustls",
     "redis-db",
-    "surrealdb-rocksdb",
-    "surrealdb-mem",
+    "surreal",
     "key-store",
     "advanced",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,32 +35,25 @@ mysql-rustls = ["sqlx/mysql", "sqlx/tls-rustls"]
 mysql-native = ["sqlx/mysql", "sqlx/tls-native-tls"]
 redis-db = ["redis_pool", "redis"]
 redis-clusterdb = ["redis_pool/cluster", "redis/cluster-async"]
-surrealdb-rocksdb =  ["surrealdb/kv-rocksdb", "surrealdb_tag"]
-surrealdb-tikv =  ["surrealdb/kv-tikv", "surrealdb_tag"]
-surrealdb-fdb-6_1 =  ["surrealdb/kv-fdb-6_1", "surrealdb_tag"]
-surrealdb-fdb-6_2 =  ["surrealdb/kv-fdb-6_2", "surrealdb_tag"]
-surrealdb-fdb-6_3 =  ["surrealdb/kv-fdb-6_3", "surrealdb_tag"]
-surrealdb-fdb-7_0 =  ["surrealdb/kv-fdb-7_0", "surrealdb_tag"]
-surrealdb-fdb-7_1 =  ["surrealdb/kv-fdb-7_1", "surrealdb_tag"]
-surrealdb-mem =  ["surrealdb/kv-mem", "surrealdb_tag"]
+surreal = ["dep:surrealdb"]
 mongo = ["mongodb"]
 rest_mode = []
 advanced = []
 
-#private features.
-surrealdb_tag = []
-
 [dependencies]
-axum-core = {version = "0.3.4"}
+axum-core = { version = "0.3.4" }
 serde = { version = "1.0.192", features = ["derive"] }
 serde_json = "1.0.108"
-chrono = { version = "0.4.31", default-features = false, features = ["clock", "serde"] }
+chrono = { version = "0.4.31", default-features = false, features = [
+    "clock",
+    "serde",
+] }
 tokio = { version = "1.34.0", features = ["full"] }
 async-trait = "0.1.74"
 tracing = "0.1.40"
 thiserror = "1.0.50"
 http-body = "0.4.5"
-uuid = { version = "1.5.0", features = ["serde","v4"] }
+uuid = { version = "1.5.0", features = ["serde", "v4"] }
 http = "0.2.10"
 tower-layer = "0.3.2"
 tower-service = "0.3.2"
@@ -74,20 +67,31 @@ futures = "0.3.29"
 bytes = "1.5.0"
 dashmap = "5.5.3"
 redis_pool = { version = "0.2.1", optional = true }
-redis = { version = "0.23.3", features = ["aio", "tokio-comp"], optional = true }
+redis = { version = "0.23.3", features = [
+    "aio",
+    "tokio-comp",
+], optional = true }
 surrealdb = { version = "1.0.0", optional = true }
-aes-gcm = { version = "0.10.3"}
-base64 = { version = "0.21.5"}
-rand = { version = "0.8.5"}
-fastbloom-rs = {version = "0.5.7", optional = true }
+aes-gcm = { version = "0.10.3" }
+base64 = { version = "0.21.5" }
+rand = { version = "0.8.5" }
+fastbloom-rs = { version = "0.5.7", optional = true }
 mongodb = { version = "2.7.1", optional = true }
 
 [dev-dependencies]
-axum = { version = "0.6.20", features = ["macros"]}
+axum = { version = "0.6.20", features = ["macros"] }
 hyper = "0.14.27"
 tower = "0.4.13"
 log = { version = "0.4.20", default-features = false }
 
 [package.metadata.docs.rs]
-features = ["sqlite-rustls", "mysql-rustls", "redis-db", "surrealdb-rocksdb", "surrealdb-mem", "key-store", "advanced"]
+features = [
+    "sqlite-rustls",
+    "mysql-rustls",
+    "redis-db",
+    "surrealdb-rocksdb",
+    "surrealdb-mem",
+    "key-store",
+    "advanced",
+]
 rustdoc-args = ["--document-private-items"]

--- a/examples/middleware_layer/Cargo.toml
+++ b/examples/middleware_layer/Cargo.toml
@@ -5,9 +5,9 @@ authors = ["Andrew Wheeler <genusistimelord@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-axum = {version = "0.6.18"}
+axum = { version = "0.6.18" }
 tokio = { version = "1.29.1", features = ["full", "tracing"] }
 async-trait = "0.1.71"
-axum_session = { path = "../../", features = [ "surrealdb-mem"] }
-surrealdb = { version = "1.0.0" , features = ["kv-mem"]}
+axum_session = { path = "../../", features = ["surreal"] }
+surrealdb = { version = "1.0.0", features = ["kv-mem"] }
 hyper = "0.14"

--- a/examples/rest_test/Cargo.toml
+++ b/examples/rest_test/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Andrew Wheeler <genusistimelord@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-axum = {version = "0.6.18"}
+axum = { version = "0.6.18" }
 tokio = { version = "1.29.1", features = ["full", "tracing"] }
 async-trait = "0.1.71"
-axum_session = { path = "../../", features = [ "surrealdb-mem", "rest_mode"] }
-surrealdb = { version = "1.0.0" , features = ["kv-mem"]}
+axum_session = { path = "../../", features = ["surreal", "rest_mode"] }
+surrealdb = { version = "1.0.0", features = ["kv-mem"] }
 tower = "0.4.13"
 hyper = "0.14.27"

--- a/examples/surrealdb/Cargo.toml
+++ b/examples/surrealdb/Cargo.toml
@@ -5,8 +5,8 @@ authors = ["Andrew Wheeler <genusistimelord@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-axum = {version = "0.6.18"}
+axum = { version = "0.6.18" }
 tokio = { version = "1.29.1", features = ["full", "tracing"] }
 async-trait = "0.1.71"
-axum_session = { path = "../../", features = [ "surrealdb-mem"] }
-surrealdb = { version = "1.0.0" , features = ["kv-mem"]}
+axum_session = { path = "../../", features = ["surreal"] }
+surrealdb = { version = "1.0.0", features = ["kv-mem"] }

--- a/examples/surrealdb/src/main.rs
+++ b/examples/surrealdb/src/main.rs
@@ -8,7 +8,7 @@ use surrealdb::opt::auth::Root;
 #[tokio::main]
 async fn main() {
     // Create the Surreal connection.
-    let db = connect("ws://localhost:8080").await.unwrap();
+    let db = connect("ws://localhost:8000").await.unwrap();
 
     // sign in as our account.
     db.signin(Root {

--- a/src/databases.rs
+++ b/src/databases.rs
@@ -28,9 +28,9 @@ mod mongodb;
 #[cfg(feature = "mongo")]
 pub use self::mongodb::*;
 
-#[cfg(feature = "surrealdb_tag")]
+#[cfg(feature = "surreal")]
 mod surreal;
-#[cfg(feature = "surrealdb_tag")]
+#[cfg(feature = "surreal")]
 pub use self::surreal::*;
 
 mod any_db;

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -33,10 +33,10 @@ pub enum SessionError {
     UUID(#[from] uuid::Error),
     #[error(transparent)]
     UTF8(#[from] std::string::FromUtf8Error),
-    #[cfg(feature = "surrealdb_tag")]
+    #[cfg(feature = "surreal")]
     #[error(transparent)]
     SurrealDBError(#[from] surrealdb::Error),
-    #[cfg(feature = "surrealdb_tag")]
+    #[cfg(feature = "surreal")]
     #[error(transparent)]
     SurrealDBDatabaseError(#[from] surrealdb::error::Db),
     #[error("unknown Session store error")]


### PR DESCRIPTION
From what I can tell axum session does not use any specific surrealdb features, so it can have a single surreal feature and let the consumer choose the surrealdb features directly. 