### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ async fn main() {
     // run it
     let addr = SocketAddr::from(([0, 0, 0, 0], 8000));
 
-    debug!("listening on {}", addr);
+    println!("listening on {}", addr);
     let listener = TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
 }
@@ -165,7 +165,7 @@ async fn main() {
     // run it
     let addr = SocketAddr::from(([0, 0, 0, 0], 8000));
 
-    debug!("listening on {}", addr);
+    println!("listening on {}", addr);
     let listener = TcpListener::bind(addr).await.unwrap();
 
     //we then start the actual service.
@@ -184,7 +184,6 @@ async fn main() {
 ## 💿 Example SessionNullPool for non_persistant Memory store only.
 
 ```rust ignore
-use sqlx::{ConnectOptions, postgres::{PgPoolOptions, PgConnectOptions}};
 use std::net::SocketAddr;
 use axum_session::{Session, SessionNullPool, SessionConfig, SessionStore, SessionLayer};
 use axum::{
@@ -209,7 +208,7 @@ async fn main() {
     // run it
     let addr = SocketAddr::from(([0, 0, 0, 0], 8000));
 
-    debug!("listening on {}", addr);
+    println!("listening on {}", addr);
     let listener = TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
 }
@@ -253,7 +252,7 @@ async fn main() {
     // run it
     let addr = SocketAddr::from(([0, 0, 0, 0], 8000));
 
-    debug!("listening on {}", addr);
+    println!("listening on {}", addr);
     let listener = TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
 }


### PR DESCRIPTION
Make the examples closed to compiling 'as is'.

Changes:

* Change `debug!` (which isn't imported) with `println!`. This seems reasonable for a little demo?
* Remove imports of database in the "in memory" example (which is the one I wanted to cut+paste), as they aren't needed and also don't work without adding another package?

With these two tiny changes, the 'in memory' example does now build and run as is.