### PR TITLE
Replace UPDATE with UPSERT

### DIFF
--- a/databases/surreal/src/lib.rs
+++ b/databases/surreal/src/lib.rs
@@ -112,7 +112,7 @@ impl<C: Connection> DatabasePool for SessionSurrealPool<C> {
     ) -> Result<(), DatabaseError> {
         self.connection
         .query(
-            "UPDATE type::thing($table_name, $session_id) SET sessionstore = $store, sessionexpires = $expire, sessionid = $session_id;",
+            "UPSERT type::thing($table_name, $session_id) SET sessionstore = $store, sessionexpires = $expire, sessionid = $session_id;",
         )
         .bind(("table_name", table_name.to_string()))
         .bind(("session_id", id.to_string()))


### PR DESCRIPTION
Possible fix for [issue 36](https://github.com/AscendingCreations/AxumSessionAuth/issues/36).

This PR replaces the use of `UPDATE` with `UPSERT`. According to the [SurrealQL documentation](https://github.com/AscendingCreations/AxumSessionAuth/issues/36), `UPSERT` ensures that records are created if they don't already exist, addressing the issue where sessions were not being properly saved.

> UPDATE on a single record in SurrealDB 1.x will create the record if it does not exist. This behaviour is no longer the case in SurrealDB 2.0. To update and create a record if it does not exist in SurrealDB 2.0, use the UPSERT statement.
